### PR TITLE
Make papipp work with Papi 7.2.0b1

### DIFF
--- a/papipp.h
+++ b/papipp.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <iostream>
-#include <ostream>
 
 extern "C" {
 #include <papi.h>

--- a/papipp.h
+++ b/papipp.h
@@ -1,147 +1,180 @@
 #pragma once
+#include <iostream>
+#include <ostream>
 
-extern "C"
-{
+extern "C" {
 #include <papi.h>
 }
 
 #include <cstddef>
 #include <array>
 #include <string>
+#include <stdexcept>
 
 #define likely_true(x)   __builtin_expect(!!(x), 1)
 #define likely_false(x)  __builtin_expect(!!(x), 0)
 
 namespace papi
 {
+    using event_code = int;
+    using papi_counter = long long;
 
-using event_code = int;
-using papi_counter = long long;
-
-inline std::string get_event_code_name(event_code code)
-{
-    std::array<char, PAPI_MAX_STR_LEN> event_name;
-    ::PAPI_event_code_to_name(code, event_name.data());
-
-    return event_name.data();
-}
-
-template <event_code _Event>
-struct event
-{
-    explicit event(papi_counter counter = {})
-     : _counter(counter)
-    {}
-
-    papi_counter counter() const { return _counter; }
-
-    static constexpr event_code code() { return _Event; }
-    static const std::string& name() { return s_name; }
-
-private:
-    static const std::string s_name;
-
-    papi_counter _counter;
-};
-
-template <event_code _Event>
-const std::string event<_Event>::s_name = get_event_code_name(_Event);
-
-template <typename _Stream, event_code _Event>
-inline _Stream& operator<<(_Stream& strm, const event<_Event>& evt)
-{
-    strm << evt.name() << "=" << evt.counter();
-    return strm;
-}
-
-template <event_code... _Events>
-struct event_set
-{
-    explicit event_set()
-    {}
-
-    void start_counters()
+    inline std::string get_event_code_name(event_code code)
     {
-        int ret;
+        std::array<char, PAPI_MAX_STR_LEN> event_name;
+        ::PAPI_event_code_to_name(code, event_name.data());
 
-        if (likely_false((ret = ::PAPI_start_counters(s_events.data(), size())) != PAPI_OK))
-            throw std::runtime_error(std::string("PAPI_start_counters failed with error: ") + PAPI_strerror(ret));
+        return event_name.data();
     }
 
-    void reset_counters()
+    template <event_code _Event>
+    struct event
     {
-        int ret;
+        explicit event(papi_counter counter = {})
+            : _counter(counter)
+        {
+        }
 
-        if (likely_false((ret = ::PAPI_read_counters(_counters.data(), size())) != PAPI_OK))
-            throw std::runtime_error(std::string("PAPI_read_counters failed with error: ") + PAPI_strerror(ret));
+        papi_counter counter() const { return _counter; }
+
+        static constexpr event_code code() { return _Event; }
+        static const std::string& name() { return s_name; }
+
+    private:
+        static const std::string s_name;
+
+        papi_counter _counter;
+    };
+
+    template <event_code _Event>
+    const std::string event<_Event>::s_name = get_event_code_name(_Event);
+
+    template <typename _Stream, event_code _Event>
+    inline _Stream& operator<<(_Stream& strm, const event<_Event>& evt)
+    {
+        strm << evt.name() << "=" << evt.counter();
+        return strm;
     }
 
-    void stop_counters()
+    template <event_code... _Events>
+    struct event_set
     {
-        int ret;
+        explicit event_set()
+        {
+            if (!_init)
+            {
+                int retval = PAPI_library_init(PAPI_VER_CURRENT);
+                if (retval != PAPI_VER_CURRENT)
+                    throw std::runtime_error("PAPI initialization failed");
+                /* Initialize the EventSet */
+                retval = PAPI_create_eventset(&_event_set);
+                if (retval != PAPI_OK)
+                    throw std::runtime_error("PAPI create eventset failed");
+                for (auto const& e : s_events)
+                {
+                    // Add events one by one. Maybe this allows to home in on errors better, not sure.
+                    auto retval = PAPI_add_event(_event_set, e);
+                    if (retval != PAPI_OK)
+                        throw std::runtime_error("PAPI add event failed");
+                }
+                _init = true;
+            }
+        }
 
-        if (likely_false((ret = ::PAPI_stop_counters(_counters.data(), size())) != PAPI_OK))
-            throw std::runtime_error(std::string("PAPI_stop_counters failed with error: ") + PAPI_strerror(ret));
+        ~event_set()
+        {
+            int retval = PAPI_remove_events(_event_set,s_events.data(),s_events.size());
+            if (retval != PAPI_OK)
+                std::cerr << "PAPI remove events failed" << std::endl;
+            retval = PAPI_destroy_eventset(&_event_set);
+            if (retval != PAPI_OK)
+                std::cerr << "PAPI destroy eventset failed "
+                    << PAPI_strerror(retval) << std::endl;
+        }
+
+        void start_counters()
+        {
+            int ret;
+
+            if (likely_false((ret = ::PAPI_start(_event_set)) != PAPI_OK))
+                throw std::runtime_error(std::string("PAPI_start_counters failed with error: ") + PAPI_strerror(ret));
+        }
+
+        void reset_counters()
+        {
+            int ret;
+
+            if (likely_false((ret = ::PAPI_reset(_event_set)) != PAPI_OK))
+                throw std::runtime_error(std::string("PAPI_reset failed with error: ") + PAPI_strerror(ret));
+        }
+
+        void stop_counters()
+        {
+            int ret;
+            if (likely_false((ret = ::PAPI_stop(_event_set, _counters.data())) != PAPI_OK))
+                throw std::runtime_error(std::string("PAPI_stop_counters failed with error: ") + PAPI_strerror(ret));
+        }
+
+        static constexpr std::size_t size() { return sizeof...(_Events); }
+        //static_assert(size() > 0, "at least one hardware event has to be in the set");
+
+        template <std::size_t _EventIndex>
+        auto at() const
+        {
+            static constexpr const std::array<event_code, sizeof...(_Events)> events = {{_Events...}};
+            constexpr event_code code = events[_EventIndex];
+            return event<code>(_counters[_EventIndex]);
+        }
+
+        template <event_code _EventCode>
+        auto get() const
+        {
+            static constexpr const std::array<event_code, sizeof...(_Events)> events = {{_Events...}};
+
+            constexpr int eventIndex = find(_EventCode, events, sizeof...(_Events), 0);
+            static_assert(eventIndex != -1, "EventCode not present in this event_set");
+            return at<eventIndex>();
+        }
+
+    private:
+        bool _init{false};
+        int _event_set{PAPI_NULL};
+
+        template <typename ArrayT>
+        static constexpr int find(event_code x, ArrayT& ar, std::size_t size, std::size_t i)
+        {
+            return size == i ? -1 : (ar[i] == x ? i : find(x, ar, size, i + 1));
+        }
+
+        static std::array<event_code, sizeof...(_Events)> s_events;
+
+        std::array<papi_counter, sizeof...(_Events)> _counters;
+    };
+
+    template <event_code... _Events>
+    std::array<event_code, sizeof...(_Events)> event_set<_Events...>::s_events = {{_Events...}};
+
+    namespace detail
+    {
+        template <std::size_t N, typename _Stream, event_code... _Events>
+        inline std::enable_if_t<N == event_set<_Events...>::size()>
+        to_stream(_Stream&, const event_set<_Events...>&)
+        {
+        }
+
+        template <std::size_t N, typename _Stream, event_code... _Events>
+        inline std::enable_if_t<N < event_set<_Events...>::size()>
+        to_stream(_Stream& strm, const event_set<_Events...>& set)
+        {
+            strm << set.template at<N>() << " ";
+            detail::to_stream<N + 1>(strm, set);
+        }
     }
 
-    static constexpr std::size_t size() { return sizeof...(_Events); }
-    //static_assert(size() > 0, "at least one hardware event has to be in the set");
-
-    template <std::size_t _EventIndex>
-    auto at() const
+    template <typename _Stream, event_code... _Events>
+    inline _Stream& operator<<(_Stream& strm, const event_set<_Events...>& set)
     {
-        static constexpr const std::array<event_code, sizeof...(_Events)> events = {{_Events...}};
-        constexpr event_code code = events[_EventIndex];
-        return event<code>(_counters[_EventIndex]);
+        detail::to_stream<0>(strm, set);
+        return strm;
     }
-
-    template <event_code _EventCode>
-    auto get() const
-    {
-        static constexpr const std::array<event_code, sizeof...(_Events)> events = {{_Events...}};
-
-        constexpr int eventIndex = find(_EventCode, events, sizeof...(_Events), 0);
-        static_assert(eventIndex != -1, "EventCode not present in this event_set");
-        return at<eventIndex>();
-    }
-
-private:
-    template <typename ArrayT>
-    static constexpr int find(event_code x, ArrayT& ar, std::size_t size, std::size_t i)
-    {
-        return size == i ? -1 : (ar[i] == x ? i : find(x, ar, size, i + 1));
-    }
-
-    static std::array<event_code, sizeof...(_Events)> s_events;
-
-    std::array<papi_counter, sizeof...(_Events)> _counters;
-};
-
-template <event_code... _Events>
-std::array<event_code, sizeof...(_Events)> event_set<_Events...>::s_events = {{_Events...}};
-
-namespace detail
-{
-
-template <std::size_t N, typename _Stream, event_code... _Events>
-inline std::enable_if_t<N == event_set<_Events...>::size()>
-to_stream(_Stream&, const event_set<_Events...>&) { }
-
-template <std::size_t N, typename _Stream, event_code... _Events>
-inline std::enable_if_t<N < event_set<_Events...>::size()>
-to_stream(_Stream& strm, const event_set<_Events...>& set)
-{
-    strm << set.template at<N>() << " ";
-    detail::to_stream<N + 1>(strm, set);
-}
-
-}
-
-template <typename _Stream, event_code... _Events>
-inline _Stream& operator<<(_Stream& strm, const event_set<_Events...>& set)
-{
-    detail::to_stream<0>(strm, set);
-    return strm;
-}
-
 }


### PR DESCRIPTION
This pull request fixes issues in `papipp.h` that prevented it from working correctly with recent PAPI versions (tested with a version from [https://icl.utk.edu/papi/](https://icl.utk.edu/papi/)). 

**Verification:**

*   Unit tests pass.
*   An example program using the wrapper appears to function correctly.

